### PR TITLE
fetch join 사용하여 n+1 문제 해결하기

### DIFF
--- a/src/main/java/com/example/querydsl/StudentController.java
+++ b/src/main/java/com/example/querydsl/StudentController.java
@@ -17,9 +17,17 @@ public class StudentController {
 
     private final StudentRepositoryCustom studentRepository;
 
-    @GetMapping("/students")
+    @GetMapping("/v1/students")
     public ResponseEntity<?> getStudentsByName(@RequestParam String name) {
         List<StudentResponseDto> students = studentRepository.findByName(name).stream().map(StudentResponseDto::new).toList();
         return ResponseEntity.ok(students);
     }
+
+    @GetMapping("/v2/students")
+    public ResponseEntity<?> getStudentsByNameFetchAcademy(@RequestParam String name) {
+        List<StudentResponseDto> students = studentRepository.findByNameFetchAcademy(name).stream().map(StudentResponseDto::new).toList();
+        return ResponseEntity.ok(students);
+    }
+
+
 }

--- a/src/main/java/com/example/querydsl/StudentRepositoryCustom.java
+++ b/src/main/java/com/example/querydsl/StudentRepositoryCustom.java
@@ -21,4 +21,12 @@ public class StudentRepositoryCustom {
                 .fetch();
     }
 
+    public List<Student> findByNameFetchAcademy(String name) {
+        return jpaQueryFactory.selectFrom(QStudent.student)
+                .join(QStudent.student.academy).fetchJoin()
+                .where(QStudent.student.name.eq(name))
+                .fetch();
+    }
+
+
 }

--- a/src/test/java/com/example/querydsl/StudentApiTest.java
+++ b/src/test/java/com/example/querydsl/StudentApiTest.java
@@ -7,13 +7,25 @@ import org.junit.jupiter.api.Test;
 public class StudentApiTest extends RestApiTest {
 
     @Test
-    @DisplayName("학생 이름으로 학생 조회 - 아카데미 fetch 테스트")
+    @DisplayName("학생 이름으로 학생 조회 - fetch join 없이 사용")
     public void getStudentsByNameTest() {
         RestAssured.given()
                 .param("name", "바보")
                 .when()
-                .get("http://localhost:8081/students")
+                .get("http://localhost:8081/v1/students")
                 .then()
                 .statusCode(200);
     }
+
+    @Test
+    @DisplayName("학생 이름으로 학생 조회 - fetch join 사용")
+    public void getStudentsByNameFetchAcademyTest() {
+        RestAssured.given()
+                .param("name", "바보")
+                .when()
+                .get("http://localhost:8081/v2/students")
+                .then()
+                .statusCode(200);
+    }
+
 }


### PR DESCRIPTION

<img width="295" alt="스크린샷 2024-06-08 오후 4 56 57" src="https://github.com/yunhwane/querydsl-example/assets/147581818/1b0985a5-83a6-4604-8bd4-0a7545b59969">


연관된 데이터를 조회할때, 만약 초기화가 필요한 데이터라면 fetch join을 사용하여 성능 최적화를 진행한다.